### PR TITLE
fix: timeout error caused by missing Content-Type when uploading

### DIFF
--- a/mirai_core/__init__.py
+++ b/mirai_core/__init__.py
@@ -3,4 +3,4 @@ from .updater import Updater
 from . import models
 from . import exceptions
 
-__VERSION__ = '0.10.0'
+__VERSION__ = '0.10.1'

--- a/mirai_core/network.py
+++ b/mirai_core/network.py
@@ -1,6 +1,7 @@
 from typing import Dict
 import aiohttp
 from aiohttp import client_exceptions
+from pathlib import Path
 from .log import create_logger
 from io import BytesIO
 
@@ -100,7 +101,7 @@ class HttpClient:
             raise NetworkException('Unable to reach Mirai console')
         return await HttpClient._check_response(response, url, 'post')
 
-    async def upload(self, url, headers=None, data=None, file: str = None):
+    async def upload(self, url, file: Path, headers=None, data=None):
         """
         upload using multipart upload
 
@@ -112,7 +113,11 @@ class HttpClient:
         """
         if data is None:
             data = dict()
-        data['img'] = BytesIO(open(str(file.absolute()), 'rb').read())
+        data['img'] = BytesIO(open(file, 'rb').read())
+
+        headers = headers or {}
+        headers["Content-Type"] = "multipart/form-data"
+
         self.logger.debug(f'upload {url} with file: {file}')
         try:
             response = await self.session.post(self.base_url + url,


### PR DESCRIPTION
`mirai-api-http`要求上传的多媒体内容使用`multipart`请求。具体而言，在`mirai_core.network.HttpClient.upload`中应当显式地指定`Content-Type`为`multipart/form-data`。

参考：[mirai-api-http > HttpAdapter > 多媒体内容上传][1]

其中提到，_"如果发送错误的请求,API将不会返回任何数据,也不会断开连接"_。从而 `aiohttp` session 会在等待 `DEFAULT_TIMEOUT` (5秒) 后抛出超时错误。用户将观察到，无论何时发送多大的图像都会发生超时错误。

[1]: https://github.com/project-mirai/mirai-api-http/blob/master/docs/adapter/HttpAdapter.md#%E5%A4%9A%E5%AA%92%E4%BD%93%E5%86%85%E5%AE%B9%E4%B8%8A%E4%BC%A0